### PR TITLE
Reset NetworkUnavailable condition on GCE

### DIFF
--- a/kube.go
+++ b/kube.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	log "github.com/golang/glog"
+	"golang.org/x/net/context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
+)
+
+func resetNodeCondition(ctx context.Context) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			client, err := getKubeClient()
+			if err != nil {
+				log.Warningf("Failed to create kube client: %v", err)
+				continue
+			}
+			patch, err := formatPatch()
+			if err != nil {
+				log.Warningf("Failed to format patch: %v", err)
+				continue
+			}
+			_, err = client.CoreV1().Nodes().PatchStatus(opts.kubeNode, patch)
+			if err != nil {
+				log.Warningf("Failed to update node status, will retry: %v", err)
+				continue
+			}
+			log.Infof("Successfully updated node %q status", opts.kubeNode)
+			return
+		case <-ctx.Done():
+			log.Warning("Context is canceled")
+			return
+		}
+	}
+}
+
+func getKubeClient() (*kubernetes.Clientset, error) {
+	return kubernetes.NewForConfig(&rest.Config{
+		Host: fmt.Sprintf("https://%v:6443", opts.kubeAPIServer),
+		TLSClientConfig: rest.TLSClientConfig{
+			CertFile: opts.kubeCert,
+			KeyFile:  opts.kubeKey,
+			CAFile:   opts.kubeCA,
+		},
+	})
+}
+
+func formatPatch() ([]byte, error) {
+	condition := v1.NodeCondition{
+		Type:               v1.NodeNetworkUnavailable,
+		Status:             v1.ConditionFalse,
+		Reason:             "RouteCreated",
+		Message:            "Flannel created a route",
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	}
+	bytes, err := json.Marshal(&[]v1.NodeCondition{condition})
+	if err != nil {
+		return nil, err
+	}
+	return []byte(fmt.Sprintf(`{"status":{"conditions":%s}}`, bytes)), nil
+}

--- a/kube.go
+++ b/kube.go
@@ -14,9 +14,27 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// resetNodeCondition updates status of a Kubernetes node this flannel process
+// is running on to reset NetworkUnavailable condition
+//
+// On certain clouds, namely Google Compute Engine, nodes come up explicitly
+// marked with NetworkUnavailable condition which renders them unschedulable
+// and Kubernetes expects this condition to be removed either by RouteController
+// or networking plugins.
+//
+// We use neither of those: flannel does all route management (including
+// creating routes using cloud APIs using proper backend) and thus it has
+// to reset this condition itself.
+//
+// According to the current Kubernetes source code and multiple Github issues
+// this is an "expected" way to workaround this and what other people are
+// doing as well (https://github.com/kubernetes/kubernetes/issues/44254,
+// https://github.com/weaveworks/weave/issues/3249).
 func resetNodeCondition(ctx context.Context) {
-	ticker := time.NewTicker(2 * time.Second)
+	ticker := time.NewTicker(retryInterval)
 	defer ticker.Stop()
+	// retry until we succeed because the node may not be registered yet
+	// (kubelet comes up after flannel)
 	for {
 		select {
 		case <-ticker.C:
@@ -38,15 +56,17 @@ func resetNodeCondition(ctx context.Context) {
 			log.Infof("Successfully updated node %q status", opts.kubeNode)
 			return
 		case <-ctx.Done():
-			log.Warning("Context is canceled")
+			log.Warning("Context is canceled, node status wasn't updated")
 			return
 		}
 	}
 }
 
+// getKubeClient creates a new Kubernetes client using connection information
+// provided via command-line flags
 func getKubeClient() (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(&rest.Config{
-		Host: fmt.Sprintf("https://%v:6443", opts.kubeAPIServer),
+		Host: fmt.Sprintf("https://%v", opts.kubeAPIServer),
 		TLSClientConfig: rest.TLSClientConfig{
 			CertFile: opts.kubeCert,
 			KeyFile:  opts.kubeKey,
@@ -55,17 +75,24 @@ func getKubeClient() (*kubernetes.Clientset, error) {
 	})
 }
 
+// formatPatch creates a patch that modifies a node status to remove
+// NetworkUnavailable condition
 func formatPatch() ([]byte, error) {
-	condition := v1.NodeCondition{
+	bytes, err := json.Marshal(&[]v1.NodeCondition{{
 		Type:               v1.NodeNetworkUnavailable,
 		Status:             v1.ConditionFalse,
 		Reason:             "RouteCreated",
 		Message:            "Flannel created a route",
 		LastTransitionTime: metav1.NewTime(time.Now()),
-	}
-	bytes, err := json.Marshal(&[]v1.NodeCondition{condition})
+	}})
 	if err != nil {
 		return nil, err
 	}
 	return []byte(fmt.Sprintf(`{"status":{"conditions":%s}}`, bytes)), nil
 }
+
+const (
+	// retryInterval is how soon flannel will reattempt to update Kubernetes
+	// node status in case of failure
+	retryInterval = 2 * time.Second
+)

--- a/kube.go
+++ b/kube.go
@@ -22,9 +22,8 @@ import (
 // and Kubernetes expects this condition to be removed either by RouteController
 // or networking plugins.
 //
-// We use neither of those: flannel does all route management (including
-// creating routes using cloud APIs using proper backend) and thus it has
-// to reset this condition itself.
+// Since flannel is managing routes (including creating routes using cloud APIs
+// using proper backend) and thus it has to reset this condition itself.
 //
 // According to the current Kubernetes source code and multiple Github issues
 // this is an "expected" way to workaround this and what other people are

--- a/main.go
+++ b/main.go
@@ -68,6 +68,11 @@ type CmdLineOpts struct {
 	subnetDir              string
 	publicIP               string
 	subnetLeaseRenewMargin int
+	kubeAPIServer          string
+	kubeNode               string
+	kubeCert               string
+	kubeKey                string
+	kubeCA                 string
 }
 
 var (
@@ -87,6 +92,11 @@ func init() {
 	flag.StringVar(&opts.iface, "iface", "", "interface to use (IP or name) for inter-host communication")
 	flag.StringVar(&opts.subnetFile, "subnet-file", "/run/flannel/subnet.env", "filename where env variables (subnet, MTU, ... ) will be written to")
 	flag.StringVar(&opts.publicIP, "public-ip", "", "IP accessible by other nodes for inter-host communication")
+	flag.StringVar(&opts.kubeAPIServer, "kube-apiserver", "", "Kubernetes API server address")
+	flag.StringVar(&opts.kubeNode, "kube-node", "", "Kubernetes node name")
+	flag.StringVar(&opts.kubeCert, "kube-cert", "", "Kubernetes certificate file")
+	flag.StringVar(&opts.kubeKey, "kube-key", "", "Kubernetes private key file")
+	flag.StringVar(&opts.kubeCA, "kube-ca", "", "Kubernetes CA file")
 	flag.IntVar(&opts.subnetLeaseRenewMargin, "subnet-lease-renew-margin", 60, "Subnet lease renewal margin, in minutes.")
 	flag.BoolVar(&opts.ipMasq, "ip-masq", false, "setup IP masquerade rule for traffic destined outside of overlay network")
 	flag.BoolVar(&opts.kubeSubnetMgr, "kube-subnet-mgr", false, "Contact the Kubernetes API for subnet assignement instead of etcd.")
@@ -199,6 +209,7 @@ func main() {
 
 	// Start "Running" the backend network. This will block until the context is done so run in another goroutine.
 	go bn.Run(ctx)
+	go resetNodeCondition(ctx)
 	log.Infof("Finished starting backend.")
 
 	daemon.SdNotify(false, "READY=1")

--- a/main.go
+++ b/main.go
@@ -209,7 +209,9 @@ func main() {
 
 	// Start "Running" the backend network. This will block until the context is done so run in another goroutine.
 	go bn.Run(ctx)
-	go resetNodeCondition(ctx)
+	if config.BackendType == "gce" {
+		go resetNodeCondition(ctx)
+	}
 	log.Infof("Finished starting backend.")
 
 	daemon.SdNotify(false, "READY=1")


### PR DESCRIPTION
On GCE nodes come up marked with NetworkUnavailable condition which makes them unschedulable until this condition is reset. Normally, this condition gets reset by RouteController which we do not use. Flannel is essentially our "route controller" - when using GCE backend it creates routes itself. 

This PR makes flannel reset this node condition upon successful route creation. Looking at various issues on Github, that's what other people who make network plugins for Kubernetes do as well.
