### PR TITLE
During watch reset don't skip added events where backend data has changed

### DIFF
--- a/subnet/watch.go
+++ b/subnet/watch.go
@@ -15,6 +15,7 @@
 package subnet
 
 import (
+	"bytes"
 	"time"
 
 	log "github.com/golang/glog"
@@ -76,7 +77,7 @@ func (lw *leaseWatcher) reset(leases []Lease) []Event {
 
 		found := false
 		for i, ol := range lw.leases {
-			if ol.Subnet.Equal(nl.Subnet) {
+			if ol.Subnet.Equal(nl.Subnet) && bytes.Compare(ol.Attrs.BackendData, nl.Attrs.BackendData) == 0 {
 				lw.leases = deleteLease(lw.leases, i)
 				found = true
 				break
@@ -89,7 +90,7 @@ func (lw *leaseWatcher) reset(leases []Lease) []Event {
 		}
 	}
 
-	// everything left in sm.leases has been deleted
+	// everything left in lw.leases has been deleted
 	for _, l := range lw.leases {
 		if lw.ownLease != nil && l.Subnet.Equal(lw.ownLease.Subnet) {
 			continue


### PR DESCRIPTION
Fixes https://github.com/gravitational/gravity/issues/1017

This updates the flannel logic to also consider BackendData changes when resetting the leaseWatcher due to an etcd watch where the index is outside of the history window. When a node is rebooted when the watch is being reset, the current logic appears to only consider whether the subnet lease itself exists, and not if any of the data has changed. In our case, the node reboot resets the VtepMac of the node, which is stored in the BackendData field. 