### PR TITLE
fix issue with flannel during watch reset

### DIFF
--- a/subnet/watch.go
+++ b/subnet/watch.go
@@ -77,9 +77,13 @@ func (lw *leaseWatcher) reset(leases []Lease) []Event {
 
 		found := false
 		for i, ol := range lw.leases {
-			if ol.Subnet.Equal(nl.Subnet) && bytes.Compare(ol.Attrs.BackendData, nl.Attrs.BackendData) == 0 {
+			if ol.Subnet.Equal(nl.Subnet) {
 				lw.leases = deleteLease(lw.leases, i)
-				found = true
+
+				// If the backend data has changed, send the added event to the backend
+				if bytes.Compare(ol.Attrs.BackendData, nl.Attrs.BackendData) == 0 {
+					found = true
+				}
 				break
 			}
 		}


### PR DESCRIPTION
Fixes gravitational/gravity#1017
Previous PR: https://github.com/gravitational/flannel/pull/4

My previous attempt at fixing this was ineffective, since the problem is difficult to reproduce (requires specific timing). I now have a better set of steps to reproduce the issue, which identified the original issue. The problem is, the way the watch code works, is if it doesn't find a lease from the cache, it goes on to delete the entry. So we would get an add and then delete entry passed to the backend for all peers that had changed configuration. This slight adjustment ensures the lease isn't considered for deletion.

```
Feb 03 20:08:35 kevin-test4 flanneld[1038]: I0203 20:08:35.034582    1038 vxlan_network.go:138] adding subnet: 100.96.53.0/24 PublicIP: 10.162.0.7 VtepMAC: de:85:76:d3:72:dc
Feb 03 20:08:35 kevin-test4 flanneld[1038]: I0203 20:08:35.034972    1038 vxlan_network.go:138] adding subnet: 100.96.65.0/24 PublicIP: 10.162.0.6 VtepMAC: 12:8d:5d:f9:b5:77
Feb 03 20:08:35 kevin-test4 flanneld[1038]: I0203 20:08:35.035263    1038 vxlan_network.go:138] adding subnet: 100.96.74.0/24 PublicIP: 10.162.0.5 VtepMAC: 3a:6b:70:b3:0b:ab
Feb 03 20:08:35 kevin-test4 flanneld[1038]: I0203 20:08:35.035388    1038 vxlan_network.go:179] removing subnet: 100.96.65.0/24 PublicIP: 10.162.0.6 VtepMAC: fa:fc:84:64:39:5e
Feb 03 20:08:35 kevin-test4 flanneld[1038]: I0203 20:08:35.035501    1038 vxlan_network.go:179] removing subnet: 100.96.74.0/24 PublicIP: 10.162.0.5 VtepMAC: 9e:f3:07:37:ac:65
Feb 03 20:08:35 kevin-test4 flanneld[1038]: I0203 20:08:35.035595    1038 vxlan_network.go:179] removing subnet: 100.96.53.0/24 PublicIP: 10.162.0.7 VtepMAC: 06:f7:41:2e:a2:37
```

For manual verification, I've been using iptables and node restarts:
1. `root@kevin-test5:~# iptables -I INPUT 1 -p tcp --source-port 2379 -j DROP && iptables -I OUTPUT 1 -p tcp --destination-port 2379 -j DROP`

2. Restart nodes
3. Generate some etcd traffic to go past the watch history
4. `root@kevin-test5:~# iptables -D INPUT 1 && iptables -D OUTPUT 1`

Observe the better result:
```
Feb 03 20:57:15 kevin-test5 flanneld[29475]: E0203 20:57:15.959398   29475 watch.go:44] Watch subnets: client: etcd cluster is unavailable or misconfigured; error #0: read tcp 127.0.0.1:58562->127.0.0.1:2379: read: connection timed out
Feb 03 20:57:16 kevin-test5 flanneld[29475]: W0203 20:57:16.968459   29475 local_manager.go:345] Watch of subnet leases failed because etcd index outside history window
Feb 03 20:57:16 kevin-test5 flanneld[29475]: I0203 20:57:16.971181   29475 vxlan_network.go:138] adding subnet: 100.96.65.0/24 PublicIP: 10.162.0.6 VtepMAC: 5a:74:8f:aa:32:9f
Feb 03 20:57:16 kevin-test5 flanneld[29475]: I0203 20:57:16.971415   29475 vxlan_network.go:138] adding subnet: 100.96.74.0/24 PublicIP: 10.162.0.5 VtepMAC: 7e:09:75:b5:22:92
Feb 03 20:57:16 kevin-test5 flanneld[29475]: I0203 20:57:16.971502   29475 vxlan_network.go:138] adding subnet: 100.96.53.0/24 PublicIP: 10.162.0.7 VtepMAC: 8a:2b:5a:10:09:58
Feb 03 20:57:36 kevin-test5 flanneld[29475]: E0203 20:57:36.439379   29475 watch.go:176] Subnet watch failed: client: etcd cluster is unavailable or misconfigured; error #0: read tcp 127.0.0.1:58560->127.0.0.1:2379: read: connection timed out
Feb 03 20:57:37 kevin-test5 flanneld[29475]: W0203 20:57:37.448334   29475 local_manager.go:317] Watch of subnet leases failed because etcd index outside history window
Feb 03 20:57:37 kevin-test5 flanneld[29475]: I0203 20:57:37.451540   29475 main.go:418] Waiting for 22h3m40.997388723s to renew lease
```